### PR TITLE
Some minor fixes.

### DIFF
--- a/counsel-gtags.el
+++ b/counsel-gtags.el
@@ -355,7 +355,13 @@ See `counsel-gtags--async-tag-query' for more info."
 
 `process-lines' does not support Tramp because it uses `call-process'.  Using
 `process-file' makes Tramp support auto-magical."
-  (let ((global-run-buffer (get-buffer-create (format "*global @ %s*" default-directory))))
+  ;; Space before buffer name to make it "invisible"
+  (let ((global-run-buffer (get-buffer-create (format " *global @ %s*" default-directory))))
+    ;; The buffer needs to be cleared, this can be done after split-string,
+    ;; but for now it is better to keep it like this for debugging purposed
+    ;; between calls
+    (with-current-buffer global-run-buffer
+      (erase-buffer))
     (apply #'process-file "global"
 	   nil ;; no input file
 	   global-run-buffer;;BUFFER
@@ -383,7 +389,6 @@ This is for internal use and not for final user."
 			  ("" '())
 			  (_ (list tagname))))
 	 (global-args (append (reverse options) query-as-list)))
-    
     (apply #'counsel-gtags--process-lines "global" global-args)))
 
 (defun counsel-gtags--select-file (type tagname &optional extra-options auto-select-only-candidate)
@@ -393,18 +398,20 @@ Use TYPE ∈ '(definition reference symbol) for defining global parameters.
 Use TAGNAME for global query.
 Use AUTO-SELECT-ONLY-CANDIDATE to skip `ivy-read' if have a single candidate.
 Extra command line parameters to global are forwarded through EXTRA-OPTIONS."
-  (let* ((root (counsel-gtags--default-directory))
-         (encoding buffer-file-coding-system)
-         (default-directory root)
-         (collection (counsel-gtags--collect-candidates
-                      type tagname encoding extra-options))
-         (ivy-auto-select-single-candidate t) ;; see issue #7
-         )
-    (if (and auto-select-only-candidate (= (length collection) 1))
-        (counsel-gtags--find-file (car collection))
-      (ivy-read "Pattern: " collection
-                :action #'counsel-gtags--find-file
-                :caller 'counsel-gtags--select-file))))
+  (if (string-empty-p tagname)
+      (message "No candidate tags")
+    (let* ((root (counsel-gtags--default-directory))
+           (encoding buffer-file-coding-system)
+           (default-directory root)
+           (collection (counsel-gtags--collect-candidates
+			type tagname encoding extra-options))
+           (ivy-auto-select-single-candidate t) ;; see issue #7
+           )
+      (if (and auto-select-only-candidate (= (length collection) 1))
+          (counsel-gtags--find-file (car collection))
+	(ivy-read "Pattern: " collection
+                  :action #'counsel-gtags--find-file
+                  :caller 'counsel-gtags--select-file)))))
 
 ;;;###autoload
 (defun counsel-gtags-find-definition (tagname)

--- a/counsel-gtags.el
+++ b/counsel-gtags.el
@@ -362,7 +362,7 @@ See `counsel-gtags--async-tag-query' for more info."
     ;; between calls
     (with-current-buffer global-run-buffer
       (erase-buffer))
-    (apply #'process-file "global"
+    (apply #'process-file command
 	   nil ;; no input file
 	   global-run-buffer;;BUFFER
 	   nil ;;DISPLAY
@@ -471,8 +471,8 @@ Useful for jumping from a location when using global commands (like with
 			    file-path))
 			candidates
 			)))
-    (remove-duplicates files
-		       :test #'string-equal)))
+    (cl-remove-duplicates files
+			  :test #'string-equal)))
 
 ;;;###autoload
 (defun counsel-gtags-find-file (&optional filename)


### PR DESCRIPTION
counsel-gtags--process-lines: cleared the buffer before the
process-file call because results were accumulating.

counsel-gtags--select-file: added a check condition to not call global
with an empty tag candidate because the error was being printed in the
ivy buffer. (counsel-gtags--read-tag could return nil)

This is just a bugfix, so I don't know if you need a test for this.