### PR TITLE
--color=never is not a valid option for ag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ before_install:
   - cat ~/.ssh/id_this_travis_build.pub >> ~/.ssh/authorized_keys
   - printf "%s\n" 'Host localhost' '  IdentityFile ~/.ssh/id_this_travis_build' >> ~/.ssh/config
   - ssh -o StrictHostKeyChecking=no localhost echo I can ssh to localhost OK
+  # install The Silver Searcher (ag) for filtering
+  - sudo apt-get install silversearcher-ag
   # PPA for Emacs nightlies
   - sudo add-apt-repository -y ppa:ubuntu-elisp/ppa
   # Update and install the Emacs for our environment

--- a/counsel-gtags.el
+++ b/counsel-gtags.el
@@ -109,6 +109,10 @@ This variable does not have any effect unless
 (defvar counsel-gtags--original-default-directory nil
   "Last `default-directory' where command is invoked.")
 
+(defvar counsel-gtags--grep-commands '("rg" "ag" "grep")
+  "List of grep-like commands to filter candidates.
+The first command available is used to do the filtering.")
+
 (defun counsel-gtags--select-gtags-label ()
   "Get label from user to be used to generate tags."
   (let ((labels '("default" "native" "ctags" "pygments")))
@@ -191,7 +195,7 @@ Returns a command without arguments.
 
 Otherwise, returns nil if couldn't find any."
   (cl-loop
-   for command in (list grep-command "rg" "ag" "grep")
+   for command in (cons grep-command counsel-gtags--grep-commands)
    for actual-command = (and command
 			     (let ((command-no-args (car
 						     (split-string command))))

--- a/counsel-gtags.el
+++ b/counsel-gtags.el
@@ -113,6 +113,11 @@ This variable does not have any effect unless
   "List of grep-like commands to filter candidates.
 The first command available is used to do the filtering.")
 
+(defvar counsel-gtags--grep-commands-no-color-options
+  '(("ag" . "--nocolor"))
+  "List of grep-like commands with their options to suppress colored output.
+By default \"--color=never\" is used.")
+
 (defun counsel-gtags--select-gtags-label ()
   "Get label from user to be used to generate tags."
   (let ((labels '("default" "native" "ctags" "pygments")))
@@ -200,6 +205,13 @@ Otherwise, returns nil if couldn't find any."
 			     (let ((command-no-args (car
 						     (split-string command))))
 			       (executable-find command-no-args)))
+   for actual-command = (and actual-command
+                             (concat
+                              actual-command " "
+                              (or (cdr (assoc
+                                        (file-name-base actual-command)
+                                        counsel-gtags--grep-commands-no-color-options))
+                                  "--color=never")))
    while (not actual-command)
    finally return actual-command))
 
@@ -218,7 +230,6 @@ ivy's default filter `counsel--async-filter' is too slow with lots of tags."
 	      " ")
    " | "
    (counsel-gtags--get-grep-command) " "
-   "--color=never" " "
    (thread-last (ivy--regex query)
      (counsel--elisp-to-pcre)
      (shell-quote-argument))))

--- a/counsel-gtags.el
+++ b/counsel-gtags.el
@@ -111,7 +111,10 @@ This variable does not have any effect unless
 
 (defvar counsel-gtags--grep-commands '("rg" "ag" "grep")
   "List of grep-like commands to filter candidates.
-The first command available is used to do the filtering.")
+The first command available is used to do the filtering.  `grep-command', if
+non-nil and available, has a higher priority than any entries in this list.
+Use `counsel-gtags--grep-commands-no-color-options' to specify the options
+to suppress colored output.")
 
 (defvar counsel-gtags--grep-commands-no-color-options
   '(("ag" . "--nocolor"))
@@ -198,7 +201,10 @@ precedence over default \"--result=grep\"."
 
 Returns a command without arguments.
 
-Otherwise, returns nil if couldn't find any."
+Otherwise, returns nil if couldn't find any.
+
+Use `counsel-gtags--grep-commands' to specify a list of commands to be
+checked for availability."
   (cl-loop
    for command in (cons grep-command counsel-gtags--grep-commands)
    for actual-command = (and command

--- a/test/unit-tests.el
+++ b/test/unit-tests.el
@@ -401,6 +401,27 @@ tested with a call to `shell-command-to-string' and `split-string' like
 		   "the_second_func"
 		   "the_third_func"))))))))
 
+(ert-deftest correct-no-color-option-for-ag ()
+  "See https://github.com/FelipeLema/emacs-counsel-gtags/issues/11"
+  (ert--skip-unless (executable-find "ag"))
+  (let ((counsel-gtags--grep-commands '("ag" "grep" "rg")))
+    (should
+     (string-suffix-p "ag --nocolor" (counsel-gtags--get-grep-command)))))
+
+(ert-deftest correct-no-color-option-for-grep ()
+  "See https://github.com/FelipeLema/emacs-counsel-gtags/issues/11"
+  (ert--skip-unless (executable-find "grep"))
+  (let ((counsel-gtags--grep-commands '("grep" "rg" "ag")))
+    (should
+     (string-suffix-p "grep --color=never" (counsel-gtags--get-grep-command)))))
+
+(ert-deftest correct-no-color-option-for-rg ()
+  "See https://github.com/FelipeLema/emacs-counsel-gtags/issues/11"
+  (ert--skip-unless (executable-find "rg"))
+  (let ((counsel-gtags--grep-commands '("rg" "ag" "grep")))
+    (should
+     (string-suffix-p "rg --color=never" (counsel-gtags--get-grep-command)))))
+
 
 
 (provide 'unit-tests)


### PR DESCRIPTION
The option `--color=never` introduced in https://github.com/FelipeLema/emacs-counsel-gtags/commit/af1ecbc2ecc235281bc3a86871c824bdf962eaf2 does not always work, e.g. `ag` uses `--nocolor` instead.

I created a new variable `counsel-gtags--grep-commands-no-color-options` where the color suppressing options can be defined for each command in case they differ from `--color=never` which is used by default.

