### PR TITLE
Added counsel-gtags-use-pulse-momentary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,12 @@ all: test
 # Use LC_ALL=C to avoid locale dependencies in the dates!
 test: clean
 	LC_ALL=C $(BEMACS) -l test/setup-unit-tests.el \
-	       -l counsel-gtags.el \
-	       -l test/unit-tests.el \
-	       -f ert-run-tests-batch-and-exit
+	      	-l counsel-gtags.el \
+	       	-l test/unit-tests.el \
+	       	-f ert-run-tests-batch-and-exit
 
 compile:
-	$(EMACS) -Q -batch -f batch-byte-compile counsel-gtags.el
+	$(EMACS) -batch -f batch-byte-compile counsel-gtags.el
 
 clean:
 	rm -f f.elc

--- a/counsel-gtags.el
+++ b/counsel-gtags.el
@@ -304,7 +304,7 @@ function will add this information correctly."
 	(pulse-momentary-highlight-one-line (point)))
     t))
 
-(defun counsel-gtags--jump-to-candidate (candidate)
+(defun counsel-gtags--jump-to-candidate (candidate &optional no-push)
   "Call `find-file' and `forward-line' on file location from CANDIDATE .
 
 Calls `counsel-gtags--push' at the end if PUSH is non-nil.
@@ -315,7 +315,7 @@ Returns (buffer line)"
 	(context (counsel-gtags--file-and-line candidate)))
     (when (counsel-gtags--goto-context context)
       (plist-put context :direction 'to)
-      (if (not counsel-gtags--other-window)
+      (unless (or no-push counsel-gtags--other-window)
 	  (counsel-gtags--push context))
       ;; position correctly within the file
       context)))

--- a/counsel-gtags.el
+++ b/counsel-gtags.el
@@ -29,9 +29,7 @@
 ;;; Code:
 
 (require 'counsel)
-(require 'cl-lib)
 (require 'rx)
-(require 'seq)
 (require 'pulse)
 
 (declare-function cygwin-convert-file-name-from-windows "cygw32.c")
@@ -524,14 +522,14 @@ Prompt for TAGNAME if not given."
 Useful for jumping from a location when using global commands (like with
 \"--from-here\")."
   (setq counsel-gtags--original-default-directory
-        (cl-case counsel-gtags-path-style
-          ((relative absolute) default-directory)
-          (through (or (getenv "GTAGSROOT")
-		       (locate-dominating-file default-directory "GTAGS")
-		       ;; If file doesn't exist create it?
-		       (if (yes-or-no-p "File GTAGS not found. Run 'gtags'? ")
-			   (call-interactively 'counsel-gtags-create-tags)
-			 (error "Abort generating tag files")))))))
+        (pcase counsel-gtags-path-style
+          ((or 'relative 'absolute) default-directory)
+          ('through (or (getenv "GTAGSROOT")
+			(locate-dominating-file default-directory "GTAGS")
+			;; If file doesn't exist create it?
+			(if (yes-or-no-p "File GTAGS not found. Run 'gtags'? ")
+			    (call-interactively 'counsel-gtags-create-tags)
+			  (error "Abort generating tag files")))))))
 
 ;;;###autoload
 (defun counsel-gtags-find-file (&optional filename)
@@ -567,7 +565,7 @@ Useful for jumping from a location when using global commands (like with
     (user-error "Context stack is empty"))
   (let ((position counsel-gtags--context-position)
         (num-entries (length counsel-gtags--context-stack)))
-    (while (and (< (cl-incf position) num-entries)
+    (while (and (< (setq position (1+ position)) num-entries)
 		(not (counsel-gtags--try-go position))))))
 
 ;;;###autoload
@@ -577,7 +575,7 @@ Useful for jumping from a location when using global commands (like with
   (unless counsel-gtags--context-stack
     (user-error "Context stack is empty"))
   (let ((position counsel-gtags--context-position))
-    (while (and (>= (cl-decf position) 0)
+    (while (and (>= (setq position (1- position)) 0)
 		(not (counsel-gtags--try-go position))))))
 
 (defun counsel-gtags--push (new-context)

--- a/counsel-gtags.el
+++ b/counsel-gtags.el
@@ -400,15 +400,11 @@ See `counsel-gtags--async-tag-query' for more info."
 `process-lines' does not support Tramp because it uses `call-process'.  Using
 `process-file' makes Tramp support auto-magical."
   ;; Space before buffer name to make it "invisible"
-  (let* ((caller-buffer (current-buffer)))
-    (with-temp-buffer
-      (let ((temp-buffer (current-buffer)))
-
-	(with-current-buffer caller-buffer
-	  (process-file-shell-command command nil temp-buffer nil)
-	  (counsel-gtags--debug-message "process-lines command: %s" command))
-
-	(split-string (buffer-string) "\n" t)))))
+  (with-temp-buffer
+    (counsel-gtags--debug-message "process-lines command: %s" command)
+    (process-file-shell-command command  nil (current-buffer))
+    (counsel-gtags--debug-message "process-lines output: %s" (buffer-string))
+    (split-string (buffer-string) "\n" t)))
 
 (defun counsel-gtags--collect-candidates (type tagname extra-options)
   "Collect lines for ⎡global …⎦ using TAGNAME as query.

--- a/counsel-gtags.el
+++ b/counsel-gtags.el
@@ -91,6 +91,9 @@ arriving to Emacs.  This option is useful specially when using
 tramp and the candidates list is not huge."
   :type 'boolean)
 
+(defcustom counsel-gtags-use-pulse-momentary t
+  "Enable momentary highlight for the current line after a jump with counsel-gtags."
+  :type 'boolean)
 
 (defconst counsel-gtags--prompts-alist
   '((definition . "Find Definition: ")
@@ -290,6 +293,8 @@ Returns (buffer line)"
       ;; position correctly within the file
       (goto-char (point-min))
       (forward-line (1- line))
+      (if counsel-gtags-use-pulse-momentary
+	  (pulse-momentary-highlight-one-line (point)))
       (back-to-indentation)
       (if (and push
 	       (not counsel-gtags--other-window))
@@ -503,6 +508,8 @@ Return t on success, nil otherwise."
                 (t nil)))
       (goto-char (point-min))
       (forward-line (1- (plist-get context :line)))
+      (if counsel-gtags-use-pulse-momentary
+	  (pulse-momentary-highlight-one-line (point)))
       t)))
 
 ;;;###autoload

--- a/counsel-gtags.el
+++ b/counsel-gtags.el
@@ -402,15 +402,15 @@ See `counsel-gtags--async-tag-query' for more info."
 `process-lines' does not support Tramp because it uses `call-process'.  Using
 `process-file' makes Tramp support auto-magical."
   ;; Space before buffer name to make it "invisible"
-  (let* ((global-run-buffer (get-buffer-create (format " *global @ %s*" default-directory)))
-	 (lines (progn
-		  (with-current-buffer global-run-buffer
-		    (erase-buffer))
-		  (process-file-shell-command command nil global-run-buffer nil)
-		  (with-current-buffer global-run-buffer
-		    (split-string (buffer-string) "\n" t)))))
-    (counsel-gtags--debug-message "process-lines command: %s" command)
-    lines))
+  (let* ((caller-buffer (current-buffer)))
+    (with-temp-buffer
+      (let ((temp-buffer (current-buffer)))
+
+	(with-current-buffer caller-buffer
+	  (process-file-shell-command command nil temp-buffer nil)
+	  (counsel-gtags--debug-message "process-lines command: %s" command))
+
+	(split-string (buffer-string) "\n" t)))))
 
 (defun counsel-gtags--collect-candidates (type tagname extra-options)
   "Collect lines for ⎡global …⎦ using TAGNAME as query.

--- a/test/unit-tests.el
+++ b/test/unit-tests.el
@@ -460,7 +460,7 @@ tested with a call to `shell-command-to-string' and `split-string' like
 						    ("grep" . "--color=never")
 						    ("rg" . "--color never"))))
     (should
-     (string-suffix-p "ag --nocolor" (counsel-gtags--search-grep-command)))))
+     (string-suffix-p "ag --nocolor " (counsel-gtags--search-grep-command)))))
 
 (ert-deftest correct-no-color-option-for-grep ()
   "See https://github.com/FelipeLema/emacs-counsel-gtags/issues/11"
@@ -470,7 +470,7 @@ tested with a call to `shell-command-to-string' and `split-string' like
 						    ("rg" . "--color never")
 						    ("ag" . "--nocolor"))))
     (should
-     (string-suffix-p "grep --color=never" (counsel-gtags--search-grep-command)))))
+     (string-suffix-p "grep --color=never " (counsel-gtags--search-grep-command)))))
 
 (ert-deftest correct-no-color-option-for-rg ()
   "See https://github.com/FelipeLema/emacs-counsel-gtags/issues/11"
@@ -480,7 +480,7 @@ tested with a call to `shell-command-to-string' and `split-string' like
 						    ("ag" . "--nocolor")
 						    ("grep" . "--color=never"))))
     (should
-     (string-suffix-p "rg --color never" (counsel-gtags--search-grep-command)))))
+     (string-suffix-p "rg --color never " (counsel-gtags--search-grep-command)))))
 
 (ert-deftest propertized-argument-confuses-ivy ()
   "See https://github.com/FelipeLema/emacs-counsel-gtags/issues/15"

--- a/test/unit-tests.el
+++ b/test/unit-tests.el
@@ -178,7 +178,7 @@ int main{
 
 (ert-deftest 00-environment-have-grep-command ()
   "Assert that we have a grep tool of any kind"
-  (should (counsel-gtags--get-grep-command-find)))
+  (should (counsel-gtags--search-grep-command)))
 
 ;;;;;;;;;;;;;;;;;
 ;; Actual testing
@@ -456,25 +456,31 @@ tested with a call to `shell-command-to-string' and `split-string' like
   "See https://github.com/FelipeLema/emacs-counsel-gtags/issues/11"
   (ert--skip-unless (executable-find "ag"))
   (let ((counsel-gtags--get-grep-command nil)
-	(counsel-gtags--grep-commands-list '("ag" "grep" "rg")))
+	(counsel-gtags-grep-command-options-alist '(("ag" . "--nocolor")
+						    ("grep" . "--color=never")
+						    ("rg" . "--color never"))))
     (should
-     (string-suffix-p "ag --nocolor" (counsel-gtags--get-grep-command-find)))))
+     (string-suffix-p "ag --nocolor" (counsel-gtags--search-grep-command)))))
 
 (ert-deftest correct-no-color-option-for-grep ()
   "See https://github.com/FelipeLema/emacs-counsel-gtags/issues/11"
   (ert--skip-unless (executable-find "grep"))
   (let ((counsel-gtags--get-grep-command nil)
-	(counsel-gtags--grep-commands-list '("grep" "rg" "ag")))
+	(counsel-gtags-grep-command-options-alist '(("grep" . "--color=never")
+						    ("rg" . "--color never")
+						    ("ag" . "--nocolor"))))
     (should
-     (string-suffix-p "grep --color=never" (counsel-gtags--get-grep-command-find)))))
+     (string-suffix-p "grep --color=never" (counsel-gtags--search-grep-command)))))
 
 (ert-deftest correct-no-color-option-for-rg ()
   "See https://github.com/FelipeLema/emacs-counsel-gtags/issues/11"
   (ert--skip-unless (executable-find "rg"))
   (let ((counsel-gtags--get-grep-command nil)
-	(counsel-gtags--grep-commands-list '("rg" "ag" "grep")))
+	(counsel-gtags-grep-command-options-alist '(("rg" . "--color never")
+						    ("ag" . "--nocolor")
+						    ("grep" . "--color=never"))))
     (should
-     (string-suffix-p "rg --color never" (counsel-gtags--get-grep-command-find)))))
+     (string-suffix-p "rg --color never" (counsel-gtags--search-grep-command)))))
 
 (ert-deftest propertized-argument-confuses-ivy ()
   "See https://github.com/FelipeLema/emacs-counsel-gtags/issues/15"


### PR DESCRIPTION
This will highlight the line with the pulse library.
Also made a refactor to reuse some code and avoid repeating.
Simplify the while loops in counsel-gtags-go-{forward/backward}.
Update the tests.
And unify the code to always use contexts.